### PR TITLE
Updated Cmake and Udev rules for Ubuntu based systems.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,19 +1,50 @@
 cmake_minimum_required(VERSION 3.10)
-
 project(Hyperx)
 
-set(C++_STANDARD 17)
-set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_HOME_DIRECTORY}/bin)
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_HOME_DIRECTORY}/bin)
+# Use C++17 cleanly
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/bin)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/bin)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 find_package(PkgConfig REQUIRED)
 find_package(wxWidgets REQUIRED COMPONENTS core base)
-find_package(hidapi REQUIRED)
 
-add_executable(Hyperx src/main.cpp src/hyperxApp.cpp src/hyperxFrame.cpp
-                      src/SwitchCtrl.cpp src/dialog.cpp)
+# First try the official CMake config for hidapi, then fall back to pkg-config
+find_package(hidapi CONFIG QUIET)
+
+if(NOT TARGET hidapi::hidapi)
+  # Try common backend packages in order: hidraw, libusb, generic
+  pkg_check_modules(HIDAPI_HIDRAW QUIET IMPORTED_TARGET hidapi-hidraw)
+  pkg_check_modules(HIDAPI_LIBUSB QUIET IMPORTED_TARGET hidapi-libusb)
+  pkg_check_modules(HIDAPI_GENERIC QUIET IMPORTED_TARGET hidapi)
+
+  if(HIDAPI_HIDRAW_FOUND)
+    add_library(hidapi::hidapi INTERFACE IMPORTED)
+    target_link_libraries(hidapi::hidapi INTERFACE PkgConfig::HIDAPI_HIDRAW)
+  elseif(HIDAPI_LIBUSB_FOUND)
+    add_library(hidapi::hidapi INTERFACE IMPORTED)
+    target_link_libraries(hidapi::hidapi INTERFACE PkgConfig::HIDAPI_LIBUSB)
+  elseif(HIDAPI_GENERIC_FOUND)
+    add_library(hidapi::hidapi INTERFACE IMPORTED)
+    target_link_libraries(hidapi::hidapi INTERFACE PkgConfig::HIDAPI_GENERIC)
+  else()
+    message(FATAL_ERROR "Could not find hidapi (neither CMake config nor pkg-config backends). Install libhidapi-dev.")
+  endif()
+endif()
+
 include(${wxWidgets_USE_FILE})
+
+add_executable(Hyperx
+  src/main.cpp
+  src/hyperxApp.cpp
+  src/hyperxFrame.cpp
+  src/SwitchCtrl.cpp
+  src/dialog.cpp
+)
+
 target_link_libraries(Hyperx PRIVATE hidapi::hidapi ${wxWidgets_LIBRARIES})
-include_directories(Hyperx PRIVATE ${CMAKE_HOME_DIRECTORY}/include
-                    ${wxWidgets_INCLUDE_DIRS})
+target_include_directories(Hyperx PRIVATE ${CMAKE_SOURCE_DIR}/include ${wxWidgets_INCLUDE_DIRS})
+

--- a/Readme.md
+++ b/Readme.md
@@ -34,6 +34,11 @@ A simple application to provite the missing features on linux
 
 - wxWidgets
 - hidapi
+On ubuntu:
+```
+sudo apt update && sudo apt upgrade -y
+sudo apt install libwxgtk3.2-dev wx3.2-headers libhidapi-dev libhidapi-libusb0 libhidapi-hidraw0
+```
 
 ## Installation
 
@@ -61,7 +66,7 @@ To install HyerpxAlpha, follow these steps:
 Editing /etc/udev/rules.d/50-hidraw.rules with:
 
 ```
-SUBSYSTEMS=="usb", ATTRS{idVendor}=="03f0", MODE="0660", TAG+="uaccess"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="03f0", MODE="0660", GROUP="plugdev", TAG+="uaccess"
 ```
 
 After installation, you can run the HyerpxAlpha software with the following command:


### PR DESCRIPTION
I struggled with building this on Ubuntu 24.04.3 LTS and started to dig around in the cmake file. It is not modified so that it will find the correct package on Ubuntu systems. After success- fully compiling I could not access the device with the tag-based approach so i added a group option as well for permissions. It now works as it should on Ubuntu. Do with this merge as you wish. I am no C++ expert but I hope you find this input somewhat Valuable :)