### PR TITLE
Convert raw pointers to smart pointers for better memory management

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,18 +2,49 @@ cmake_minimum_required(VERSION 3.10)
 
 project(Hyperx)
 
-set(C++_STANDARD 17)
-set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_HOME_DIRECTORY}/bin)
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_HOME_DIRECTORY}/bin)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/bin)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/bin)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 find_package(PkgConfig REQUIRED)
 find_package(wxWidgets REQUIRED COMPONENTS core base)
-find_package(hidapi REQUIRED)
 
-add_executable(Hyperx src/main.cpp src/hyperxApp.cpp src/hyperxFrame.cpp
-                      src/SwitchCtrl.cpp src/dialog.cpp)
+# First try the official CMake config for hidapi, then fall back to pkg-config
+find_package(hidapi CONFIG QUIET)
+
+if(NOT TARGET hidapi::hidapi)
+  # Try common backend packages in order: hidraw, libusb, generic
+  pkg_check_modules(HIDAPI_HIDRAW QUIET IMPORTED_TARGET hidapi-hidraw)
+  pkg_check_modules(HIDAPI_LIBUSB QUIET IMPORTED_TARGET hidapi-libusb)
+  pkg_check_modules(HIDAPI_GENERIC QUIET IMPORTED_TARGET hidapi)
+
+  if(HIDAPI_HIDRAW_FOUND)
+    add_library(hidapi::hidapi INTERFACE IMPORTED)
+    target_link_libraries(hidapi::hidapi INTERFACE PkgConfig::HIDAPI_HIDRAW)
+  elseif(HIDAPI_LIBUSB_FOUND)
+    add_library(hidapi::hidapi INTERFACE IMPORTED)
+    target_link_libraries(hidapi::hidapi INTERFACE PkgConfig::HIDAPI_LIBUSB)
+  elseif(HIDAPI_GENERIC_FOUND)
+    add_library(hidapi::hidapi INTERFACE IMPORTED)
+    target_link_libraries(hidapi::hidapi INTERFACE PkgConfig::HIDAPI_GENERIC)
+  else()
+    message(FATAL_ERROR "Could not find hidapi (neither CMake config nor pkg-config backends). Install libhidapi-dev.")
+  endif()
+endif()
+
 include(${wxWidgets_USE_FILE})
+
+add_executable(Hyperx
+  src/main.cpp
+  src/hyperxApp.cpp
+  src/hyperxFrame.cpp
+  src/SwitchCtrl.cpp
+  src/dialog.cpp
+)
+
 target_link_libraries(Hyperx PRIVATE hidapi::hidapi ${wxWidgets_LIBRARIES})
-include_directories(Hyperx PRIVATE ${CMAKE_HOME_DIRECTORY}/include
-                    ${wxWidgets_INCLUDE_DIRS})
+target_include_directories(Hyperx PRIVATE ${CMAKE_SOURCE_DIR}/include ${wxWidgets_INCLUDE_DIRS})
+

--- a/include/SwitchCtrl.h
+++ b/include/SwitchCtrl.h
@@ -3,89 +3,93 @@
 #pragma once
 
 #include <wx/control.h>
-#include <wx/stattext.h>
 #include <wx/sizer.h>
+#include <wx/stattext.h>
 #include <wx/timer.h>
 
-wxColour WXDLLIMPEXP_CORE wxMixColours(const wxColour& firstColour, const wxColour& secondColour, int percent);
+wxColour WXDLLIMPEXP_CORE wxMixColours(const wxColour& firstColour,
+                                       const wxColour& secondColour,
+                                       int percent);
 
-class WXDLLIMPEXP_CORE wxSwitchCtrl : public wxControl
-{
-public:
-	wxSwitchCtrl() = default;
-	wxSwitchCtrl(wxWindow* parent,
-		wxWindowID id,
-		bool value = false,
-		const wxString& label = wxEmptyString,
-		const wxPoint& pos = wxDefaultPosition,
-		const wxSize& size = wxSize(30, 15),
-		long style = wxBORDER_NONE,
-		const wxValidator& validator = wxDefaultValidator,
-		const wxString& name = wxControlNameStr);
+class WXDLLIMPEXP_CORE wxSwitchCtrl : public wxControl {
+ public:
+  wxSwitchCtrl() = default;
+  wxSwitchCtrl(wxWindow* parent, wxWindowID id, bool value = false,
+               const wxString& label = wxEmptyString,
+               const wxPoint& pos = wxDefaultPosition,
+               const wxSize& size = wxSize(30, 15), long style = wxBORDER_NONE,
+               const wxValidator& validator = wxDefaultValidator,
+               const wxString& name = wxControlNameStr);
 
-	virtual void SetLabel(const wxString& label) wxOVERRIDE;
-	virtual bool SetFont(const wxFont& font) wxOVERRIDE;
-	virtual bool SetForegroundColour(const wxColour& colour) wxOVERRIDE;
-	virtual wxSize DoGetBestClientSize() const wxOVERRIDE;
+  virtual void SetLabel(const wxString& label) wxOVERRIDE;
+  virtual bool SetFont(const wxFont& font) wxOVERRIDE;
+  virtual bool SetForegroundColour(const wxColour& colour) wxOVERRIDE;
+  virtual wxSize DoGetBestClientSize() const wxOVERRIDE;
 
-	inline void Switch() { DoSwitch(!m_bIsOn, true); }
+  inline void Switch() { DoSwitch(!m_bIsOn, true); }
 
-	inline virtual void SetValue(bool state) { DoSwitch(state, false); }
-	inline bool GetValue() { return m_bIsOn; }
+  inline virtual void SetValue(bool state) { DoSwitch(state, false); }
+  inline bool GetValue() { return m_bIsOn; }
 
-	inline void SetEnabledColour(const wxColour& colour) { m_enabledColour = colour; }
-	inline void SetDisabledColour(const  wxColour& colour) { m_disabledColour = colour; }
+  inline void SetEnabledColour(const wxColour& colour) {
+    m_enabledColour = colour;
+  }
+  inline void SetDisabledColour(const wxColour& colour) {
+    m_disabledColour = colour;
+  }
 
-	/*!
-	* \brief Set the number of units the buttons needs to travel when activaded.
-	* The higher the number, the slower the animation on activate/deactivate
-	* will be. Default is 10.
-	* \param units Number of units
-	*/
-	inline void SetUnitsToScroll(int units) { m_nUnitCount = units; }
+  /*!
+   * \brief Set the number of units the buttons needs to travel when activaded.
+   * The higher the number, the slower the animation on activate/deactivate
+   * will be. Default is 10.
+   * \param units Number of units
+   */
+  inline void SetUnitsToScroll(int units) { m_nUnitCount = units; }
 
-	wxDECLARE_EVENT_TABLE();
+  wxDECLARE_EVENT_TABLE();
 
-protected:
-	void DoSwitch(bool state, bool sendEvent = true);
-	void OnAnimationTimer(wxTimerEvent& event);
+ protected:
+  void DoSwitch(bool state, bool sendEvent = true);
+  void OnAnimationTimer(wxTimerEvent& event);
 
-	void OnPaint(wxPaintEvent& event);
-	void OnSize(wxSizeEvent& event);
+  void OnPaint(wxPaintEvent& event);
+  void OnSize(wxSizeEvent& event);
 
-	void OnLeftDown(wxMouseEvent& event);
-	void OnLeftUp(wxMouseEvent& event);
-	void OnMouseMove(wxMouseEvent& event);
-	void OnMouseCaptureLost(wxMouseCaptureLostEvent& event);
+  void OnLeftDown(wxMouseEvent& event);
+  void OnLeftUp(wxMouseEvent& event);
+  void OnMouseMove(wxMouseEvent& event);
+  void OnMouseCaptureLost(wxMouseCaptureLostEvent& event);
 
-	wxStaticText* m_labelST = nullptr;
+  wxStaticText* m_labelST = nullptr;
 
-	wxBoxSizer* m_sizer = nullptr;
+  wxBoxSizer* m_sizer = nullptr;
 
-	wxColour m_enabledColour{ 50, 50, 255 };
-	wxColour m_disabledColour{ 100,100,100 };
-	wxColour m_buttonColour{ 30,30,30 };
+  wxColour m_enabledColour{50, 50, 255};
+  wxColour m_disabledColour{100, 100, 100};
+  wxColour m_buttonColour{30, 30, 30};
 
-	bool m_bIsOn = false;
+  bool m_bIsOn = false;
 
-private:
-	int m_nCurrentUnit = 0;
-	int m_nCurrentButtonPos = 0;
-	int m_yOrigin = 0;
+ private:
+  int m_nCurrentUnit = 0;
+  int m_nCurrentButtonPos = 0;
+  int m_yOrigin = 0;
 
-	int m_nUnitCount = 10;
-	double m_radius = 2.0;
+  int m_nUnitCount = 10;
+  double m_radius = 2.0;
 
-	bool m_bWillDrag = false;
-	bool m_bIsDragging = false;
+  bool m_bWillDrag = false;
+  bool m_bIsDragging = false;
 
-	wxTimer m_tAnimationTimer;
-	wxSize m_szCacheSize;
+  wxTimer m_tAnimationTimer;
+  wxSize m_szCacheSize;
 };
 
 wxDECLARE_EVENT(wxEVT_SWITCH, wxCommandEvent);
 wxDECLARE_EVENT(wxEVT_SWITCHING, wxCommandEvent);
-#define EVT_SWITCH(winid, func) wx__DECLARE_EVT1(wxEVT_SWITCH, winid, wxCommandEventHandler(func))
-#define EVT_SWITCHING(winid, func) wx__DECLARE_EVT1(wxEVT_SWITCHING, winid, wxCommandEventHandler(func))
+#define EVT_SWITCH(winid, func) \
+  wx__DECLARE_EVT1(wxEVT_SWITCH, winid, wxCommandEventHandler(func))
+#define EVT_SWITCHING(winid, func) \
+  wx__DECLARE_EVT1(wxEVT_SWITCHING, winid, wxCommandEventHandler(func))
 
-#endif // _WX_SWITCHCTRL_H_
+#endif  // _WX_SWITCHCTRL_H_

--- a/include/dialog.h
+++ b/include/dialog.h
@@ -3,18 +3,20 @@
 
 #include <wx/wx.h>
 
+#include <memory>
+
 class dialog : public wxDialog {
-public:
-  dialog(const wxChar *title, const wxPoint &pos, const wxSize &size,
-         const wxChar *staticImg);
+ public:
+  dialog(const wxChar* title, const wxPoint& pos, const wxSize& size,
+         const wxChar* staticImg);
 
   virtual ~dialog();
 
-private:
-  wxPanel *dialogPanel;
-  wxStaticBitmap *dialogLogo;
-  wxBoxSizer *dialogSizer;
-  wxTimer *dialogTimer;
+ private:
+  wxPanel* dialogPanel;
+  wxStaticBitmap* dialogLogo;
+  wxBoxSizer* dialogSizer;
+  std::unique_ptr<wxTimer> dialogTimer;
   wxBitmapBundle logo;
 };
 

--- a/include/hyperxApp.h
+++ b/include/hyperxApp.h
@@ -1,18 +1,19 @@
 #ifndef HYPERXAPP_H
 #define HYPERXAPP_H
 
-#include "hyperxFrame.h"
 #include <wx/wx.h>
 
+#include "hyperxFrame.h"
+
 class hyperxApp : public wxApp {
-public:
+ public:
   hyperxApp(bool);
   ~hyperxApp();
 
   virtual bool OnInit();
 
-private:
-  hyperxFrame *m_frame;
+ private:
+  hyperxFrame* m_frame;
   bool systray;
 };
 

--- a/include/hyperxFrame.h
+++ b/include/hyperxFrame.h
@@ -1,43 +1,45 @@
 #ifndef __HYPERXFRAME_H
 #define __HYPERXFRAME_H
 
-#include <atomic>
-#include <thread>
 #include <wx/taskbar.h>
 #include <wx/wx.h>
+
+#include <atomic>
+#include <memory>
+#include <thread>
 
 #include "SwitchCtrl.h"
 #include "alpha_w.h"
 
 // main window
 class hyperxFrame : public wxFrame {
-public:
-  hyperxFrame(const wxChar *title, const wxPoint &pos, const wxSize &size,
-              const wxChar *runDir, wxApp *app, bool useTray = false);
+ public:
+  hyperxFrame(const wxChar* title, const wxPoint& pos, const wxSize& size,
+              const wxChar* runDir, wxApp* app, bool useTray = false);
 
-private:
-  wxApp *app;
+ private:
+  wxApp* app;
   bool useTray = false;
   // Main layout
-  wxTaskBarIcon *taskBarIcon;
+  std::unique_ptr<wxTaskBarIcon> taskBarIcon;
   bool taskAvailable = false;
-  wxMenu *taskMenu;
+  wxMenu* taskMenu;
   wxIcon wicon;
-  wxButton *quitButton;
-  wxButton *hideButton;
+  wxButton* quitButton;
+  wxButton* hideButton;
   wxString m_runDir;
-  wxStaticText *connectedLabel;
+  wxStaticText* connectedLabel;
 
   // features box
-  wxStaticText *sleepTimerLabel;
-  wxChoice *sleepTimer;
-  wxStaticText *voicePromptLabel;
-  wxSwitchCtrl *voicePrompt;
-  wxStaticText *micMonitorLabel;
-  wxSwitchCtrl *micMonitor;
+  wxStaticText* sleepTimerLabel;
+  wxChoice* sleepTimer;
+  wxStaticText* voicePromptLabel;
+  wxSwitchCtrl* voicePrompt;
+  wxStaticText* micMonitorLabel;
+  wxSwitchCtrl* micMonitor;
 
   // headset data
-  headset *m_headset;
+  std::unique_ptr<headset> m_headset;
   sleep_time sleep;
   connection_status status;
   unsigned int battery;
@@ -54,16 +56,16 @@ private:
   void setTaskIcon();
   void onConnect();
   void onDisconnect();
-  void showWindow(wxTaskBarIconEvent &);
-  void showMenu(wxTaskBarIconEvent &);
-  void sleepChoice(wxCommandEvent &);
-  void voiceSwitch(wxCommandEvent &); // hide button
-  void micSwitch(wxCommandEvent &);   // hide button
-  void quit(wxCommandEvent &);        // quit button
+  void showWindow(wxTaskBarIconEvent&);
+  void showMenu(wxTaskBarIconEvent&);
+  void sleepChoice(wxCommandEvent&);
+  void voiceSwitch(wxCommandEvent&);  // hide button
+  void micSwitch(wxCommandEvent&);    // hide button
+  void quit(wxCommandEvent&);         // quit button
 
   // timer Event 5 seconds
-  wxTimer *timer;
-  void on_timer(wxTimerEvent &);
+  std::unique_ptr<wxTimer> timer;
+  void on_timer(wxTimerEvent&);
 
   // read loop for headset
   std::atomic<bool> running;

--- a/src/SwitchCtrl.cpp
+++ b/src/SwitchCtrl.cpp
@@ -1,279 +1,253 @@
 /////////////////////////////////////////////////////////////////////////////
 // Name:        src/generic/switchctrlg.cpp
 // Purpose:     Generic wxSwitchCtrl class implementation
-// Author:      Leonardo Bronstein Franceschetti <bronstein.franceschetti@protonmail.com>
-// Created:     2019-02-07
-// Copyright:   (c) 2019 wxWidgets development team
-// Licence:     wxWindows licence
+// Author:      Leonardo Bronstein Franceschetti
+// <bronstein.franceschetti@protonmail.com> Created:     2019-02-07 Copyright:
+// (c) 2019 wxWidgets development team Licence:     wxWindows licence
 /////////////////////////////////////////////////////////////////////////////
 
 #include "SwitchCtrl.h"
-#include <wx/wx.h>
+
 #include <wx/dcgraph.h>
+#include <wx/wx.h>
 
-wxColour wxMixColours(const wxColour& firstColour, const wxColour& secondColour, int percent)
-{
-	int newRed = (double)((secondColour.Red() * percent) + (firstColour.Red() * (100 - percent))) / 100;
-	int newGreen = (double)((secondColour.Green() * percent) + (firstColour.Green() * (100 - percent))) / 100;
-	int newBlue = (double)((secondColour.Blue() * percent) + (firstColour.Blue() * (100 - percent))) / 100;
+wxColour wxMixColours(const wxColour& firstColour, const wxColour& secondColour,
+                      int percent) {
+  int newRed = (double)((secondColour.Red() * percent) +
+                        (firstColour.Red() * (100 - percent))) /
+               100;
+  int newGreen = (double)((secondColour.Green() * percent) +
+                          (firstColour.Green() * (100 - percent))) /
+                 100;
+  int newBlue = (double)((secondColour.Blue() * percent) +
+                         (firstColour.Blue() * (100 - percent))) /
+                100;
 
-	return wxColour((unsigned char)newRed, (unsigned char)newGreen, (unsigned char)newBlue);
+  return wxColour((unsigned char)newRed, (unsigned char)newGreen,
+                  (unsigned char)newBlue);
 }
 
 // Implementing events
 wxDEFINE_EVENT(wxEVT_SWITCH, wxCommandEvent);
 wxDEFINE_EVENT(wxEVT_SWITCHING, wxCommandEvent);
 
-
 wxBEGIN_EVENT_TABLE(wxSwitchCtrl, wxControl)
 
-EVT_PAINT(wxSwitchCtrl::OnPaint)
-EVT_SIZE(wxSwitchCtrl::OnSize)
+    EVT_PAINT(wxSwitchCtrl::OnPaint) EVT_SIZE(wxSwitchCtrl::OnSize)
 
-EVT_LEFT_DOWN(wxSwitchCtrl::OnLeftDown)
-EVT_LEFT_UP(wxSwitchCtrl::OnLeftUp)
-EVT_MOTION(wxSwitchCtrl::OnMouseMove)
-EVT_MOUSE_CAPTURE_LOST(wxSwitchCtrl::OnMouseCaptureLost)
+        EVT_LEFT_DOWN(wxSwitchCtrl::OnLeftDown)
+            EVT_LEFT_UP(wxSwitchCtrl::OnLeftUp)
+                EVT_MOTION(wxSwitchCtrl::OnMouseMove)
+                    EVT_MOUSE_CAPTURE_LOST(wxSwitchCtrl::OnMouseCaptureLost)
 
-EVT_TIMER(12345, wxSwitchCtrl::OnAnimationTimer)
+                        EVT_TIMER(12345, wxSwitchCtrl::OnAnimationTimer)
 
-wxEND_EVENT_TABLE()
+                            wxEND_EVENT_TABLE()
 
-wxSwitchCtrl::wxSwitchCtrl(wxWindow* parent,
-	wxWindowID id,
-	bool value,
-	const wxString& label,
-	const wxPoint& pos,
-	const wxSize& size,
-	long style,
-	const wxValidator& validator,
-	const wxString& name)
-	: wxControl(parent, id, pos, size, style, validator, name), m_tAnimationTimer(this, 12345)
-{
-	m_sizer = new wxBoxSizer(wxVERTICAL);
-	m_sizer->AddStretchSpacer(1);
-	SetSizer(m_sizer);
+                                wxSwitchCtrl::wxSwitchCtrl(
+                                    wxWindow* parent, wxWindowID id, bool value,
+                                    const wxString& label, const wxPoint& pos,
+                                    const wxSize& size, long style,
+                                    const wxValidator& validator,
+                                    const wxString& name)
+    : wxControl(parent, id, pos, size, style, validator, name),
+      m_tAnimationTimer(this, 12345) {
+  m_sizer = new wxBoxSizer(wxVERTICAL);
+  m_sizer->AddStretchSpacer(1);
+  SetSizer(m_sizer);
 
-	if ( !label.IsEmpty() )
-		SetLabel(label);
+  if (!label.IsEmpty()) SetLabel(label);
 
-	SetCursor(wxCURSOR_CLOSED_HAND);
-	DoSwitch(value, false);
+  SetCursor(wxCURSOR_CLOSED_HAND);
+  DoSwitch(value, false);
 }
 
-void wxSwitchCtrl::SetLabel(const wxString& label)
-{
-	if ( !m_labelST )
-	{
-		m_labelST = new wxStaticText(this, -1, label, wxDefaultPosition, wxDefaultSize, wxALIGN_CENTRE_HORIZONTAL);
-		m_labelST->SetCursor(wxCURSOR_DEFAULT);
-		m_labelST->SetFont(GetFont());
-		m_labelST->SetForegroundColour(GetForegroundColour());
+void wxSwitchCtrl::SetLabel(const wxString& label) {
+  if (!m_labelST) {
+    m_labelST = new wxStaticText(this, -1, label, wxDefaultPosition,
+                                 wxDefaultSize, wxALIGN_CENTRE_HORIZONTAL);
+    m_labelST->SetCursor(wxCURSOR_DEFAULT);
+    m_labelST->SetFont(GetFont());
+    m_labelST->SetForegroundColour(GetForegroundColour());
 
-		m_sizer->Insert(0, m_labelST, wxSizerFlags(0).Expand().Border(wxBOTTOM, 1));
-		m_sizer->AddSpacer(m_labelST->GetSize().y);
-	}
-	else
-	{
-		m_labelST->SetLabel(label);
-	}
+    m_sizer->Insert(0, m_labelST, wxSizerFlags(0).Expand().Border(wxBOTTOM, 1));
+    m_sizer->AddSpacer(m_labelST->GetSize().y);
+  } else {
+    m_labelST->SetLabel(label);
+  }
 
-	wxControl::SetLabel(label);
-	Layout();
+  wxControl::SetLabel(label);
+  Layout();
 }
 
-bool wxSwitchCtrl::SetFont(const wxFont& font)
-{
-	if ( m_labelST )
-		m_labelST->SetFont(font);
+bool wxSwitchCtrl::SetFont(const wxFont& font) {
+  if (m_labelST) m_labelST->SetFont(font);
 
-	wxControl::SetFont(font);
-	return true;
+  wxControl::SetFont(font);
+  return true;
 }
 
-bool wxSwitchCtrl::SetForegroundColour(const wxColour& colour)
-{
-	if ( m_labelST )
-		m_labelST->SetForegroundColour(colour);
+bool wxSwitchCtrl::SetForegroundColour(const wxColour& colour) {
+  if (m_labelST) m_labelST->SetForegroundColour(colour);
 
-	wxControl::SetForegroundColour(colour);
-	return true;
+  wxControl::SetForegroundColour(colour);
+  return true;
 }
 
-wxSize wxSwitchCtrl::DoGetBestClientSize() const
-{
-	if ( m_labelST )
-	{
-		wxSize labelSize = m_labelST->GetSize();
-		return labelSize + wxSize(labelSize.x < 15 ? 20 : labelSize.x, labelSize.y);
-	}
-	else
-	{
-		return FromDIP(wxSize(m_radius * 4, m_radius * 2));
-	}
+wxSize wxSwitchCtrl::DoGetBestClientSize() const {
+  if (m_labelST) {
+    wxSize labelSize = m_labelST->GetSize();
+    return labelSize + wxSize(labelSize.x < 15 ? 20 : labelSize.x, labelSize.y);
+  } else {
+    return FromDIP(wxSize(m_radius * 4, m_radius * 2));
+  }
 }
 
-void wxSwitchCtrl::DoSwitch(bool state, bool sendEvent)
-{
-	if ( state == m_bIsOn )
-		sendEvent = false;
+void wxSwitchCtrl::DoSwitch(bool state, bool sendEvent) {
+  if (state == m_bIsOn) sendEvent = false;
 
-	if ( sendEvent )
-	{
-		wxCommandEvent event(wxEVT_SWITCHING, GetId());
-		event.SetInt(state);
-		event.Skip();
-		ProcessEvent(event);
+  if (sendEvent) {
+    wxCommandEvent event(wxEVT_SWITCHING, GetId());
+    event.SetInt(state);
+    event.Skip();
+    ProcessEvent(event);
 
-		if ( !event.GetSkipped() )
-			return;
-	}
+    if (!event.GetSkipped()) return;
+  }
 
-	m_bIsOn = state;
-	m_szCacheSize = GetClientSize();
-	m_tAnimationTimer.Start(1);
+  m_bIsOn = state;
+  m_szCacheSize = GetClientSize();
+  m_tAnimationTimer.Start(1);
 
-	if ( sendEvent )
-	{
-		wxCommandEvent* event = new wxCommandEvent(wxEVT_SWITCH, GetId());
-		event->SetInt(state);
-		QueueEvent(event);
-	}
+  if (sendEvent) {
+    wxCommandEvent* event = new wxCommandEvent(wxEVT_SWITCH, GetId());
+    event->SetInt(state);
+    QueueEvent(event);
+  }
 }
 
-void wxSwitchCtrl::OnAnimationTimer(wxTimerEvent& event)
-{
-	if ( m_bIsOn )
-	{
-		if ( m_nCurrentUnit < m_nUnitCount )
-		{
-			m_nCurrentUnit++;
-		}
-		else
-		{
-			m_nCurrentUnit = m_nUnitCount;
-			m_tAnimationTimer.Stop();
-		}
-	}
-	else
-	{
-		if ( m_nCurrentUnit > 0 )
-		{
-			m_nCurrentUnit--;
-		}
-		else
-		{
-			m_nCurrentUnit = 0;
-			m_tAnimationTimer.Stop();
-		}
-	}
+void wxSwitchCtrl::OnAnimationTimer(wxTimerEvent& event) {
+  if (m_bIsOn) {
+    if (m_nCurrentUnit < m_nUnitCount) {
+      m_nCurrentUnit++;
+    } else {
+      m_nCurrentUnit = m_nUnitCount;
+      m_tAnimationTimer.Stop();
+    }
+  } else {
+    if (m_nCurrentUnit > 0) {
+      m_nCurrentUnit--;
+    } else {
+      m_nCurrentUnit = 0;
+      m_tAnimationTimer.Stop();
+    }
+  }
 
-	m_nCurrentButtonPos = ((double)(m_nCurrentUnit * (m_szCacheSize.x - (m_radius * 2))) / m_nUnitCount);
-	Refresh(true);
-	Update();
+  m_nCurrentButtonPos =
+      ((double)(m_nCurrentUnit * (m_szCacheSize.x - (m_radius * 2))) /
+       m_nUnitCount);
+  Refresh(true);
+  Update();
 }
 
-void wxSwitchCtrl::OnPaint(wxPaintEvent& event)
-{
-	wxPaintDC dc(this);
-	wxGCDC gdc(dc);
-	wxSize clientSize = GetClientSize();
+void wxSwitchCtrl::OnPaint(wxPaintEvent& event) {
+  wxPaintDC dc(this);
+  wxGCDC gdc(dc);
+  wxSize clientSize = GetClientSize();
 
-	wxColour slideColour = wxMixColours(m_disabledColour, m_enabledColour, (m_nCurrentUnit * 100) / m_nUnitCount);
+  wxColour slideColour = wxMixColours(m_disabledColour, m_enabledColour,
+                                      (m_nCurrentUnit * 100) / m_nUnitCount);
 
-	gdc.SetBrush(wxBrush(slideColour));
-	gdc.SetPen(*wxTRANSPARENT_PEN);
-	gdc.DrawRoundedRectangle(wxPoint(0, m_yOrigin), clientSize - wxSize(0, m_yOrigin), m_radius);
+  gdc.SetBrush(wxBrush(slideColour));
+  gdc.SetPen(*wxTRANSPARENT_PEN);
+  gdc.DrawRoundedRectangle(wxPoint(0, m_yOrigin),
+                           clientSize - wxSize(0, m_yOrigin), m_radius);
 
-	gdc.SetBrush(wxBrush(m_buttonColour));
-	gdc.SetPen(*wxTRANSPARENT_PEN);
-	gdc.DrawCircle(wxPoint(m_radius + m_nCurrentButtonPos, clientSize.y - m_radius), m_radius - 1);
+  gdc.SetBrush(wxBrush(m_buttonColour));
+  gdc.SetPen(*wxTRANSPARENT_PEN);
+  gdc.DrawCircle(
+      wxPoint(m_radius + m_nCurrentButtonPos, clientSize.y - m_radius),
+      m_radius - 1);
 }
 
-void wxSwitchCtrl::OnSize(wxSizeEvent& event)
-{
-	wxSize size = event.GetSize();
+void wxSwitchCtrl::OnSize(wxSizeEvent& event) {
+  wxSize size = event.GetSize();
 
-	if ( m_labelST )
-	{
-		wxSize labelSize = m_labelST->GetBestSize();
-		size.y -= labelSize.y;
-		m_yOrigin = labelSize.y;
+  if (m_labelST) {
+    wxSize labelSize = m_labelST->GetBestSize();
+    size.y -= labelSize.y;
+    m_yOrigin = labelSize.y;
 
-		if ( size.y < labelSize.y )
-			SetMinClientSize(wxSize(labelSize.x, labelSize.y * 2));
-	}
+    if (size.y < labelSize.y)
+      SetMinClientSize(wxSize(labelSize.x, labelSize.y * 2));
+  }
 
-	m_radius = (double)size.y / 2.0;
-	m_nCurrentButtonPos = ((double)(m_nCurrentUnit * (size.x - (m_radius * 2))) / m_nUnitCount);
+  m_radius = (double)size.y / 2.0;
+  m_nCurrentButtonPos =
+      ((double)(m_nCurrentUnit * (size.x - (m_radius * 2))) / m_nUnitCount);
 
-	event.Skip();
+  event.Skip();
 }
 
-void wxSwitchCtrl::OnLeftDown(wxMouseEvent& event)
-{
-	// If the user presses clicks on the button, prepare to
-	// drag, but don't change state to dragging yet.
+void wxSwitchCtrl::OnLeftDown(wxMouseEvent& event) {
+  // If the user presses clicks on the button, prepare to
+  // drag, but don't change state to dragging yet.
 
-	int buttonWidth = m_radius * 2;
-	wxRect buttonRect(m_nCurrentButtonPos, GetClientSize().y - buttonWidth, buttonWidth, buttonWidth);
+  int buttonWidth = m_radius * 2;
+  wxRect buttonRect(m_nCurrentButtonPos, GetClientSize().y - buttonWidth,
+                    buttonWidth, buttonWidth);
 
-	if ( buttonRect.Contains(event.GetPosition()) )
-		m_bWillDrag = true;
+  if (buttonRect.Contains(event.GetPosition())) m_bWillDrag = true;
 }
 
-void wxSwitchCtrl::OnLeftUp(wxMouseEvent& event)
-{
-	if ( !m_bIsDragging )
-		DoSwitch(!m_bIsOn);
-	else
-	{
-		DoSwitch(m_nCurrentUnit >= m_nUnitCount / 2 ? true : false);
-		ReleaseMouse();
-	}
+void wxSwitchCtrl::OnLeftUp(wxMouseEvent& event) {
+  if (!m_bIsDragging)
+    DoSwitch(!m_bIsOn);
+  else {
+    DoSwitch(m_nCurrentUnit >= m_nUnitCount / 2 ? true : false);
+    ReleaseMouse();
+  }
 
-	m_bWillDrag = false;
-	m_bIsDragging = false;
+  m_bWillDrag = false;
+  m_bIsDragging = false;
 }
 
-void wxSwitchCtrl::OnMouseMove(wxMouseEvent& event)
-{
-	if ( m_bWillDrag )
-	{
-		CaptureMouse();
-		m_bIsDragging = true;
-		m_bWillDrag = false;
-	}
+void wxSwitchCtrl::OnMouseMove(wxMouseEvent& event) {
+  if (m_bWillDrag) {
+    CaptureMouse();
+    m_bIsDragging = true;
+    m_bWillDrag = false;
+  }
 
-	if ( m_bIsDragging )
-	{
-		wxSize clientSize(GetClientSize());
-		wxPoint mousePos(event.GetPosition());
+  if (m_bIsDragging) {
+    wxSize clientSize(GetClientSize());
+    wxPoint mousePos(event.GetPosition());
 
-		// Force input to be valid
-		if ( mousePos.x < 0 )
-			mousePos.x = 0;
-		else if ( mousePos.x > clientSize.x )
-			mousePos.x = clientSize.x;
+    // Force input to be valid
+    if (mousePos.x < 0)
+      mousePos.x = 0;
+    else if (mousePos.x > clientSize.x)
+      mousePos.x = clientSize.x;
 
-		int unitWidth = clientSize.x / m_nUnitCount;
+    int unitWidth = clientSize.x / m_nUnitCount;
 
-		// Calculate current button unit and its position
-		m_nCurrentUnit = mousePos.x / unitWidth;
-		m_nCurrentButtonPos = ((double)(m_nCurrentUnit * (clientSize.x - (m_radius * 2))) / m_nUnitCount);
+    // Calculate current button unit and its position
+    m_nCurrentUnit = mousePos.x / unitWidth;
+    m_nCurrentButtonPos =
+        ((double)(m_nCurrentUnit * (clientSize.x - (m_radius * 2))) /
+         m_nUnitCount);
 
-		// Update the screen for the user
-		Refresh();
-		Update();
-	}
+    // Update the screen for the user
+    Refresh();
+    Update();
+  }
 
-	event.Skip();
+  event.Skip();
 }
 
-void wxSwitchCtrl::OnMouseCaptureLost(wxMouseCaptureLostEvent& event)
-{
-	m_bWillDrag = false;
-	m_bIsDragging = false;
+void wxSwitchCtrl::OnMouseCaptureLost(wxMouseCaptureLostEvent& event) {
+  m_bWillDrag = false;
+  m_bIsDragging = false;
 
-	DoSwitch(m_nCurrentUnit >= m_nUnitCount / 2 ? true : false);
+  DoSwitch(m_nCurrentUnit >= m_nUnitCount / 2 ? true : false);
 }

--- a/src/dialog.cpp
+++ b/src/dialog.cpp
@@ -1,18 +1,18 @@
 #include "dialog.h"
+
 #include <wx/event.h>
 
-dialog::dialog(const wxChar *title, const wxPoint &pos, const wxSize &size,
-               const wxChar *staticImg)
+dialog::dialog(const wxChar* title, const wxPoint& pos, const wxSize& size,
+               const wxChar* staticImg)
     : wxDialog(NULL, -1, title, pos, size),
       logo(wxImage(staticImg, wxBITMAP_TYPE_PNG)) {
-
-  dialogTimer = new wxTimer();
+  dialogTimer = std::make_unique<wxTimer>();
   dialogTimer->Bind(wxEVT_TIMER,
-                    [this](wxTimerEvent &event) { this->Destroy(); });
+                    [this](wxTimerEvent& event) { this->Destroy(); });
   dialogTimer->Start(3000, true);
 
   this->Bind(wxEVT_CLOSE_WINDOW,
-             [this](wxCloseEvent &event) { this->Destroy(); });
+             [this](wxCloseEvent& event) { this->Destroy(); });
   dialogSizer = new wxBoxSizer(wxVERTICAL);
   dialogPanel = new wxPanel(this, wxID_ANY);
 

--- a/src/hyperxApp.cpp
+++ b/src/hyperxApp.cpp
@@ -1,6 +1,8 @@
 #include "hyperxApp.h"
-#include "hyperxFrame.h"
+
 #include <sys/param.h>
+
+#include "hyperxFrame.h"
 
 // App
 hyperxApp::hyperxApp(bool systray) : systray(systray) {}
@@ -13,9 +15,9 @@ bool hyperxApp::OnInit() {
   wxString c(resolved_path);
   c.erase(c.end() - 6, c.end());
   try {
-    hyperxFrame *m_frame = new hyperxFrame(
-        _T("HyperX Alpha"), wxDefaultPosition, wxSize(200, 400), c, this, systray);
-  } catch (std::exception &e) {
+    m_frame = new hyperxFrame(_T("HyperX Alpha"), wxDefaultPosition,
+                              wxSize(200, 400), c, this, systray);
+  } catch (std::exception& e) {
     std::cout << e.what() << std::endl;
     return false;
   }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,10 +1,13 @@
+#include <memory>
+
 #include "hyperxApp.h"
 
-int main(int argc, char *argv[]) {
+int main(int argc, char* argv[]) {
   if (argv[1] == NULL || std::string(argv[1]) == "--systray") {
-    wxApp *pApp = new hyperxApp(argv[1]);
-    hyperxApp::SetInstance(pApp);
+    std::unique_ptr<wxApp> pApp = std::make_unique<hyperxApp>(argv[1] != NULL);
+    wxApp::SetInstance(pApp.get());
     wxEntry(argc, argv);
+    pApp.release();  // wxWidgets manages cleanup, don't delete it
     wxEntryCleanup();
   } else {
     std::cout << "HyperX Alpha Help" << std::endl;


### PR DESCRIPTION
- alpha_w.h: Convert hid_device handle to unique_ptr with custom hid_close deleter
- hyperxFrame: Convert m_headset, timer, and taskBarIcon to unique_ptr
- dialog: Convert dialogTimer to unique_ptr to prevent memory leak on early close
- hyperxApp: Fix local variable shadowing member variable m_frame
- main.cpp: Convert heap-allocated wxApp to unique_ptr with proper release handling

These changes eliminate manual delete calls and prevent memory leaks by leveraging RAII principles. wxWidgets window objects are still managed by the framework as before.

I have also run clang-format (with `--style=Google`) to ensure consistent formatting throughout the codebase.